### PR TITLE
Add theme attribution feature

### DIFF
--- a/main.go
+++ b/main.go
@@ -182,8 +182,14 @@ func (m Model) convertTheme(themeInfo ThemeInfo) tea.Cmd {
 			return errorMsg{fmt.Sprintf("Failed to load theme: %v", err)}
 		}
 
+		// Try to load extension metadata for attribution
+		var extensionMetadata *ExtensionMetadata
+		if metadata, err := LoadExtensionMetadata(themeInfo.Path); err == nil {
+			extensionMetadata = metadata
+		}
+
 		// Convert to Warp theme
-		warpTheme, err := ConvertVSCodeToWarp(vscodeTheme)
+		warpTheme, err := ConvertVSCodeToWarp(vscodeTheme, extensionMetadata)
 		if err != nil {
 			return errorMsg{fmt.Sprintf("Failed to convert theme: %v", err)}
 		}

--- a/warp.go
+++ b/warp.go
@@ -11,11 +11,12 @@ import (
 
 // WarpTheme represents a Warp theme YAML structure
 type WarpTheme struct {
-	Accent     string            `yaml:"accent"`
-	Background string            `yaml:"background"`
-	Details    string            `yaml:"details"`
-	Foreground string            `yaml:"foreground"`
+	Accent         string         `yaml:"accent"`
+	Background     string         `yaml:"background"`
+	Details        string         `yaml:"details"`
+	Foreground     string         `yaml:"foreground"`
 	TerminalColors TerminalColors `yaml:"terminal_colors"`
+	BasedOn        string         `yaml:"based_on,omitempty"`
 }
 
 // TerminalColors represents the terminal color palette
@@ -37,7 +38,7 @@ type ColorPalette struct {
 }
 
 // ConvertVSCodeToWarp converts a VS Code theme to Warp theme format
-func ConvertVSCodeToWarp(vscodeTheme *VSCodeTheme) (*WarpTheme, error) {
+func ConvertVSCodeToWarp(vscodeTheme *VSCodeTheme, extensionMetadata *ExtensionMetadata) (*WarpTheme, error) {
 	warpTheme := &WarpTheme{}
 
 	// Set basic properties
@@ -62,6 +63,9 @@ func ConvertVSCodeToWarp(vscodeTheme *VSCodeTheme) (*WarpTheme, error) {
 	} else {
 		warpTheme.Details = "darker"
 	}
+
+	// Set attribution based on extension metadata
+	warpTheme.BasedOn = FormatBasedOnAttribution(vscodeTheme.Name, extensionMetadata)
 
 	// Convert terminal colors
 	warpTheme.TerminalColors = convertTerminalColors(vscodeTheme.Colors)
@@ -197,4 +201,24 @@ func cleanFilename(name string) string {
 	name = strings.Trim(name, "_")
 	
 	return name
+}
+
+// FormatBasedOnAttribution creates a "based on" attribution string from extension metadata and theme name
+func FormatBasedOnAttribution(themeName string, metadata *ExtensionMetadata) string {
+	if metadata == nil {
+		return fmt.Sprintf("Based on %s", themeName)
+	}
+	
+	// Try different sources for author information
+	var author string
+	if metadata.Author.Name != "" {
+		author = metadata.Author.Name
+	} else if metadata.Publisher != "" {
+		author = metadata.Publisher
+	} else {
+		// Fall back to just the theme name
+		return fmt.Sprintf("Based on %s", themeName)
+	}
+	
+	return fmt.Sprintf("Based on %s by %s", themeName, author)
 }


### PR DESCRIPTION
Adds attribution information to converted Warp themes by including original theme author/publisher info from VS Code extensions in a 'based_on' field in the generated YAML files. This provides proper credit to original theme creators and improves user understanding of theme origins.